### PR TITLE
Fully implement `recv` and `close`

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -76,6 +76,7 @@ impl Peer {
     }
 }
 
+#[allow(dead_code)]
 pub struct Server {
     ring: IoUring,
     user_data: u64,


### PR DESCRIPTION
This patch:

- Maintains a `Vec` of `Peer` objects that have connected
- Adds a `Close` event type for cleaning up file descriptors
- Modifies `Receive` to call `recv` until all data has been read from the socket
- Adds pretty-printing to data returned from the socket