### PR TITLE
Combine Reactor + Executor into a Runtime

### DIFF
--- a/src/executor.rs
+++ b/src/executor.rs
@@ -105,3 +105,34 @@ pub(crate) fn new_executor_and_spawner() -> (Executor, Spawner) {
     let (task_sender, ready_queue) = sync_channel(MAX_QUEUED_TASKS);
     (Executor { ready_queue }, Spawner { task_sender })
 }
+
+/*
+   Finished dev [unoptimized + debuginfo] target(s) in 0.04s
+     Running `target/debug/iou-httpserver`
+ DEBUG iou_httpserver::executor > Spawning future
+ DEBUG iou_httpserver::executor > Spawning future
+ DEBUG iou_httpserver::executor > Polling future
+Creating accept future
+4
+ DEBUG iou_httpserver::accept_future > Submitting accept
+ DEBUG iou_httpserver::executor      > Polling future
+5
+ DEBUG iou_httpserver::accept_future > Submitting accept
+ TRACE iou_httpserver::runtime       > tick
+ DEBUG iou_httpserver::reactor       > Submitting entry 0 to io uring
+ DEBUG iou_httpserver::reactor       > Submitting entry 1 to io uring
+ TRACE iou_httpserver::reactor       > Reactor has 2 events in flight
+ DEBUG iou_httpserver::reactor       > Consumed 1 entries in 1 tick
+ DEBUG iou_httpserver::reactor       > Got completion for entry 0: 6
+ DEBUG iou_httpserver::accept_future > Accept result: 6
+ DEBUG iou_httpserver::executor      > Polling future
+got result 6
+ TRACE iou_httpserver::runtime       > tick
+ TRACE iou_httpserver::reactor       > Reactor has 1 events in flight
+ DEBUG iou_httpserver::reactor       > Consumed 1 entries in 1 tick
+ DEBUG iou_httpserver::reactor       > Got completion for entry 1: -22
+ DEBUG iou_httpserver::accept_future > Accept result: -22
+ DEBUG iou_httpserver::executor      > Polling future
+thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Os { code: 22, kind: InvalidInput, message: "Invalid argument" }', src/main.rs:23:63
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+*/

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -15,7 +15,7 @@ use {
 };
 
 /// Task executor that receives tasks off of a channel and runs them.
-pub struct Executor {
+pub(crate) struct Executor {
     ready_queue: Receiver<Arc<Task>>,
 }
 
@@ -97,7 +97,7 @@ impl ArcWake for Task {
     }
 }
 
-pub fn new_executor_and_spawner() -> (Executor, Spawner) {
+pub(crate) fn new_executor_and_spawner() -> (Executor, Spawner) {
     // Maximum number of tasks to allow queueing in the channel at once.
     // This is just to make `sync_channel` happy, and wouldn't be present in
     // a real executor.

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,39 +2,25 @@ mod accept_future;
 mod executor;
 mod reactor;
 mod server;
+mod runtime;
 
-use clap::{App, Arg};
-use executor::new_executor_and_spawner;
 use pretty_env_logger;
-use std::sync::{Arc, Mutex};
-use std::thread;
-use log::trace;
+use runtime::Runtime;
 
 use accept_future::AcceptFuture;
 
 fn main() {
     pretty_env_logger::init();
+    let mut runtime = Runtime::new();
 
-    let (mut reactor, mut sender) = reactor::Reactor::new().unwrap();
-
-    let (mut executor, spawner) = new_executor_and_spawner();
-
-    let sender_clone = sender.clone();
-    spawner.spawn(async {
+    runtime.spawn(async {
         println!("Creating accept future");
-        let result = AcceptFuture::new(sender, "0.0.0.0:8888").await.unwrap();
+        let result = AcceptFuture::new( "0.0.0.0:8888").await.unwrap();
         println!("got result {}", result);
     });
 
-    spawner.spawn(async {
-        let result2 = AcceptFuture::new(sender_clone, "0.0.0.0:8889").await.unwrap();
+    runtime.block_on(async {
+        let result2 = AcceptFuture::new("0.0.0.0:8889").await.unwrap();
         println!("got result {}", result2);
     });
-
-    drop(spawner);
-
-    while executor.tick() {
-        trace!("tick");
-        reactor.tick().unwrap();
-    }
 }

--- a/src/reactor.rs
+++ b/src/reactor.rs
@@ -68,7 +68,7 @@ impl Reactor {
         Ok((reactor, tx))
     }
 
-    pub fn tick(&mut self) -> Result<(), IouError> {
+    pub fn tick(&mut self) -> Result<bool, IouError> {
         let mut inner = self.0.borrow_mut();
         // TODO do we need to manually drop these?
 
@@ -127,6 +127,6 @@ impl Reactor {
             }
         }
 
-        Ok(())
+        Ok(inner.events.len() > 0)
     }
 }

--- a/src/reactor.rs
+++ b/src/reactor.rs
@@ -26,7 +26,7 @@ const AF_INET6: u16 = libc::AF_INET6 as u16;
 const BUF_SIZE: usize = 512;
 const CHANNEL_BUFFER: usize = 10;
 
-pub type ReactorSender = SyncSender<(Entry, Callback)>;
+pub(crate) type ReactorSender = SyncSender<(Entry, Callback)>;
 
 #[derive(Error, Debug)]
 pub enum IouError {
@@ -38,11 +38,11 @@ pub enum IouError {
     Io(#[from] io::Error),
 }
 
-type Callback = Box<dyn FnOnce(i32) + Send + 'static>;
+pub(crate) type Callback = Box<dyn FnOnce(i32) + Send + 'static>;
 // TODO rename this
 
 // TODO switch this to an UnsafeCell instead of a Mutex
-pub struct Reactor(Rc<RefCell<Inner>>);
+pub(crate) struct Reactor(Rc<RefCell<Inner>>);
 
 struct Inner {
     iouring: IoUring,

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1,0 +1,78 @@
+use std::cell::RefCell;
+use io_uring::squeue::Entry;
+use std::future::Future;
+use crate::reactor::{Reactor, ReactorSender, Callback};
+use crate::executor::{Executor, Spawner, new_executor_and_spawner};
+use log::trace;
+use std::thread_local;
+
+// TODO should this be scoped thread local storage?
+thread_local!(static RUNTIME: RefCell<Option<(Spawner, ReactorSender)>> = RefCell::new(None));
+
+pub fn spawn(future: impl Future<Output = ()> + 'static + Send) {
+	RUNTIME.with(move |handle| {
+		match &*handle.borrow() {
+			Some((spawner, _)) => spawner.spawn(future),
+			None => panic!("cannot call spawn before creating a runtime")
+		}
+	})
+}
+
+pub(crate) fn register(entry: Entry, callback: Callback) {
+	RUNTIME.with(move |handle| {
+		match &*handle.borrow() {
+			Some((_, reactor_sender)) => reactor_sender.send((entry, callback)).unwrap(),
+			None => panic!("cannot call spawn before creating a runtime")
+		}
+	})
+}
+
+pub struct Runtime {
+	executor: Executor,
+	reactor: Reactor,
+	// TODO do these need to be stored on the Runtime?
+	// will the executor exit properly if they're not?
+	spawner: Option<Spawner>,
+	reactor_sender: ReactorSender,
+}
+
+impl Runtime {
+	pub fn new() -> Runtime {
+		let (reactor, reactor_sender) = Reactor::new().unwrap();
+		let (executor, spawner) = new_executor_and_spawner();
+
+		// TODO should the thread local be set when the Runtime is created or when a future is spawned?
+		let spawner_clone = spawner.clone();
+		let reactor_sender_clone = reactor_sender.clone();
+		RUNTIME.with(move |handle| {
+			handle.replace(Some((spawner_clone, reactor_sender_clone)));
+		});
+
+		Runtime {
+			reactor,
+			executor,
+			reactor_sender,
+			spawner: Some(spawner)
+		}
+	}
+
+	pub fn run(&mut self) {
+		// Drop the spawner so that the executor exits when there are no more
+		// references to the spawner
+		self.spawner.take();
+
+		while self.executor.tick() {
+			trace!("tick");
+			self.reactor.tick().unwrap();
+		}
+	}
+
+	pub fn spawn(&mut self, future: impl Future<Output = ()> + 'static + Send) {
+		spawn(future);
+	}
+
+	pub fn block_on(&mut self, future: impl Future<Output = ()> + 'static + Send) {
+		self.spawn(future);
+		self.run();
+	}
+}


### PR DESCRIPTION
also use thread local storage to pass handles to executor and reactor to futures

This is not yet working because the accept future returns an error code 22 on the second accept call.